### PR TITLE
classmethods ftw

### DIFF
--- a/docs/rolez.rst
+++ b/docs/rolez.rst
@@ -11,16 +11,17 @@ we wanted to provide a simple way to handle user roles.
 Writing a role consists of doing the following::
 
   class GuestRole(object):
-    def is_member(user, object):
+    @classmethod
+    def is_member(cls, user, object):
         """Determine wether the passed user is a member of this group"""
         if user.is_anonymous:
             return True:
         else:
             return False
 
-That's it! a role must simply be a class defining an "is_member" method that
-accepts a user and an object instace, and the role must answer True or False,
-depending on wether the passed user is a member of the group or not.
+That's it! a role must simply be a class defining an "is_member" classmethod
+that accepts a user and an object instace, and the role must answer True or 
+False, depending on wether the passed user is a member of the group or not.
 
 Using roles with models
 ========================
@@ -28,7 +29,8 @@ Using roles with models
 To make use of roles with your objects, you should use the ModelRoleMixin model
 provided in rulez.rolez.models.
 On top of extending the Mixin, your class should declare an array of roles
-classes that are relevant to it in self.roles (or override the relevant_roles method)
+classes that are relevant to it in self.roles (or override the relevant_roles
+method)
 
 This ensures that when a user's roles are not found in the cache, the program
 doesn't spend time checking every possible role defined but limits itself to
@@ -38,7 +40,7 @@ Checking for roles in rules
 ============================
 
 The most crucial part of roles is of course to be able to use them to limit
-access to some resources.   
+access to some resources.
 In order to do so, simply call the has_role() method on the model extending
 ModelRoleMixin.
 

--- a/rulez/rolez/base.py
+++ b/rulez/rolez/base.py
@@ -4,5 +4,6 @@ class AbstractRole(object):
     """
     This is an abstract class to show what a role should look like
     """
-    def is_member(self, user, obj): #pragma: nocover
+    @classmethod
+    def is_member(cls, user, obj): #pragma: nocover
         raise NotImplemented

--- a/rulez/rolez/cache_helper.py
+++ b/rulez/rolez/cache_helper.py
@@ -77,7 +77,7 @@ def get_roles(user, obj):
         user_roles = []
         relevant = obj.relevant_roles()
         for role in relevant:
-            if role().is_member(user, obj):
+            if role.is_member(user, obj):
                 user_roles.append(role)
         cache.set(roles_key(user, obj), user_roles, 1*HOUR)
         return user_roles

--- a/rulez/tests/roles_helpers.py
+++ b/rulez/tests/roles_helpers.py
@@ -15,8 +15,8 @@ class MockUser():
 
 # Testing the model inheritence
 class Tester(AbstractRole):
-    
-    def is_member(self,user, obj):
+    @classmethod
+    def is_member(cls, user, obj):
         return getattr(user, 'member', False)
     
 class TestModel(ModelRoleMixin):


### PR DESCRIPTION
consistently use `@classmethod` because we never need to make an instance of the role anyway
