### PR TITLE
Modified cach_helper.py to treat cached but empty perm lists as a cache hit

### DIFF
--- a/rulez/rolez/cache_helper.py
+++ b/rulez/rolez/cache_helper.py
@@ -73,8 +73,8 @@ def get_roles(user, obj):
     """
     # get roles for the user, if present:
     roles = cache.get(roles_key(user, obj))
-    if roles:
-        # Cache hit
+    if isinstance(roles, list):
+        # Cache hit (a miss returns NoneType rather than an empty list)
         return roles
     else:
         # we need to recompute roles for this model


### PR DESCRIPTION
Hi Chris,

Thanks for the project.

I'm not sure if this was a design decision or simply an oversight, but I noticed the cache_helper treats cached results for users determined to have no permissions the same as a cache miss.  I suppose in some instances this conservative approach might be useful (to prevent a user being denied due to a stale cache), but, at least for my project, it would be more beneficial to treat the cache as authoritative and not force an expensive re-calculation of the user's (likely non-existent) permissions.

The included pull request is for the case where this was a simple omissions.  However, if this was a design decision, would you consider making the behavior configurable via a conf setting (I'd be happy to supply a simple updated patch)?

Thanks again!
