### PR TITLE
Registering rules through decorators

### DIFF
--- a/rulez/__init__.py
+++ b/rulez/__init__.py
@@ -27,3 +27,27 @@ class rules(object):
 
         # Pass it along
         return cls
+
+
+class rule(object):
+    """On a decorated function; registers permission with the passed class.
+    """
+
+    def __init__(self, codename, model):
+        # Codename of the permission function
+        self.codename = codename
+
+        # Model to register this rule with
+        self.model = model
+
+    def __call__(self, func):
+        from . import registry
+
+        # Add function to the model
+        self.model.add_to_class(self.codename, func)
+
+        # Register the function
+        registry.register(self.codename, self.model)
+
+        # Pass it along
+        return func


### PR DESCRIPTION
Added two decorators -- `@rule` which is meant for functions and `@rules` meant for classes -- to ease in registering rules.

When declaring permission rules for a model, decorate the model with `@rules()` to auto-register all `can_FOO` functions as permission rules for that model. Decorate the model with `@rules('can_foo', 'can_bar', '...')` to be more explicit if desired.

``` python
import rulez

@rulez.rules()
class Foo(models.Model):
    def can_read(self, user):
        return False

# or to be explicit ...

@rulez.rules('can_read')
class Bar(models.Model):
    def can_read(self, user):
        return False
```

When declaring a permission rule outside of the model, decorate with `@rule(codename, cls)` as follows:

``` python
from django.contrib.auth.models import User
import rulez

@rulez.rule('can_read', User)
def user_can_read(obj, user):
    return False
```

I believe it makes declaring rules a bit cleaner and more pythonic. I tentatively placed the decorators in `rulez/__init__.py`. Opinions? 
